### PR TITLE
now the input file should load from the path

### DIFF
--- a/pyrk/driver.py
+++ b/pyrk/driver.py
@@ -190,11 +190,25 @@ def print_logo(curr_dir):
                          logo.read())
 
 
+def load_infile(infile_path):
+    """Loads the input file as a python package import based on the path
+
+    :param infile_path: path to the infile
+    :type infile_path: string
+    """
+    import os.path
+    import sys
+    file_dir = os.path.dirname(infile_path)
+    sys.path.append(file_dir)
+    file_name = os.path.basename(infile_path).rstrip('.py')
+    infile = importlib.import_module(file_name)
+    return infile
+
+
 def main(args, curr_dir):
     np.set_printoptions(precision=5, threshold=np.inf)
     logger.set_up_pyrklog(args.logfile)
-    infile = importlib.import_module(args.infile)
-
+    infile = load_infile(args.infile)
     si = sim_info.SimInfo(timer=infile.ti,
                           components=infile.components,
                           iso=infile.fission_iso,


### PR DESCRIPTION
This may be a fix for #22 . @xwa9860 , can you test that this works on your computer?

The infile CLI argument should now accept any relative or absolute path, with or without .py at the end, from any directory . With this change, the following commands load the file on my machine. . . 

```
cd ~/repos/pyrk/pyrk
python driver.py --infile '../examples/pbfhr/fvm_react_insertion.py'
python driver.py --infile '../examples/pbfhr/fvm_react_insertion'
python driver.py --infile '../examples/pbfhr/fvm_react_insertion'
```
or from the examples directory

```
cd ~/repos/pyrk/examples/
python ../pyrk/driver.py --infile 'pbfhr/fvm_react_insertion.py'
python ../pyrk/driver.py --infile 'pbfhr/fvm_react_insertion'
```

or within the directory holding the input file itself:

```
cd ~/repos/pyrk/examples/pbfhr/
python ../../pyrk/driver.py --infile 'fvm_react_insertion'
python ../../pyrk/driver.py --infile 'fvm_react_insertion.py'
python ../../pyrk/driver.py --infile fvm_react_insertion
python ../../pyrk/driver.py --infile fvm_react_insertion.py
```
