### PR TITLE
Speedup

### DIFF
--- a/pyrk/density_model.py
+++ b/pyrk/density_model.py
@@ -9,8 +9,8 @@ class DensityModel(object):
     """
 
     def __init__(self,
-                 a=0*units.kg/units.meter**3,
-                 b=0*units.kg/units.kelvin/units.meter**3,
+                 a=0*units.kg/pow(units.meter, 3),
+                 b=0*units.kg/units.kelvin/pow(units.meter, 3),
                  model="linear"):
         """
         Initializes the DensityModel object.

--- a/pyrk/density_model.py
+++ b/pyrk/density_model.py
@@ -23,7 +23,7 @@ class DensityModel(object):
         :type b: float
         """
         self.a = a.to(units.kg/pow(units.meter, 3))
-        self.b = b
+        self.b = b.to(units.kg/units.kelvin/pow(units.meter, 3))
 
         self.implemented = {'constant': self.constant,
                             'linear': self.linear}
@@ -65,4 +65,4 @@ class DensityModel(object):
         :type temp: float. units of kelvin
         """
         ret = self.a + self.b*temp
-        return ret.to(units.kg/pow(units.meter, 3))
+        return ret

--- a/pyrk/density_model.py
+++ b/pyrk/density_model.py
@@ -22,7 +22,7 @@ class DensityModel(object):
         :param b: second coefficient of the model.
         :type b: float
         """
-        self.a = a
+        self.a = a.to(units.kg/pow(units.meter, 3))
         self.b = b
 
         self.implemented = {'constant': self.constant,
@@ -55,7 +55,7 @@ class DensityModel(object):
         :param temp: The temperature of the object
         :type temp: float.
         """
-        return self.a.to(units.kg/pow(units.meter, 3))
+        return self.a
 
     def linear(self, temp=0.0*units.kelvin):
         """

--- a/pyrk/tests/test_density_model.py
+++ b/pyrk/tests/test_density_model.py
@@ -4,7 +4,7 @@ from nose.tools import assert_equal, assert_almost_equal, assert_true, \
 from utilities.ur import units
 import density_model
 
-u_dens = units.kg/units.meter**3
+u_dens = units.kg/pow(units.meter, 3)
 alpha = 2.0*u_dens
 beta = 3.0*u_dens/units.kelvin
 

--- a/pyrk/tests/test_th_component.py
+++ b/pyrk/tests/test_th_component.py
@@ -14,7 +14,7 @@ vol = 20*units.meter**3
 k = 10*units.watt/units.meter/units.kelvin
 cp = 10*units.joule/units.kg/units.kelvin
 dm = density_model.DensityModel(a=0*units.kg/units.meter**3,
-                                b=100*units.kg/units.meter**3,
+                                b=100*units.kg/units.kelvin/pow(units.meter, 3),
                                 model='constant')
 mat = Material(k=k, cp=cp, dm=dm)
 


### PR DESCRIPTION
This should speed things up in the dtempdt function by avoiding repeated unit conversion. Very short change. 

The conversion "to" function was taking up a significant (hot pink in the picture below) amount of runtime. 
![image](https://cloud.githubusercontent.com/assets/393899/15336313/e2fb36d0-1c2a-11e6-9488-3aadddd4f64c.png)
