### PR TITLE
#48 Removing Python 3.3 from build; this version of Python is now EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
Removing Python 3.3 from the build; this version of Python is end of life. 