### PR TITLE
thermal conductivity of graphite 

### DIFF
--- a/pyrk/materials/graphite.py
+++ b/pyrk/materials/graphite.py
@@ -40,7 +40,7 @@ class Graphite(Material):
         Also noted in:
         http://www.osti.gov/scitech/servlets/purl/714896/
         """
-        return 0.26 * units.watt / (units.meter * units.kelvin)
+        return 150.0 * units.watt / (units.meter * units.kelvin)
 
     def specific_heat_capacity(self):
         """Specific heat capacity for H451 graphite [J/kg/K]


### PR DESCRIPTION
I reviewed the text in graphite.py and it stated that the thermal conductivity of graphite was between 150 w/mk and 135 w/mk (dependent whether or not the heat travels parallel or perpendicular to its axis). The prior graphite.py had its thermal conductivity as 0.26 w/mk (I don't believe this number is correct). 
I have gathered data via the IAEA for this type of graphite and I will be placing the csv file into the docs as well as create a thermal conductivity extrapolation function like density has.  