### PR TITLE
#66 Add py37 support in Travis now the py37 has been released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # whitelist
 branches:


### PR DESCRIPTION
Adding py37 support in Travis -- turning the crank to keep things up to date.