### PR TITLE
Adding Py37 to the build now that 3.7.1 is released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7-dev" ]]; then
-      conda create -q -n test-environment python=3.7 scipy numpy matplotlib nose pytables flake8
+      conda create -q -n test-environment python=3.7 scipy numpy matplotlib nose pytables flake8;
     else
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy matplotlib nose pytables flake8
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy matplotlib nose pytables flake8;
     fi
   - source activate test-environment
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,7 @@ branches:
 
 # command to install dependencies
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7-dev" ]]; then
-      PYTHON_VERSION=3.7
-    else
-      PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-    fi
-  - if [[ "$PYTHON_VERSION" == "2.7" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -36,7 +31,11 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$PYTHON_VERSION scipy numpy matplotlib nose pytables flake8
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7-dev" ]]; then
+      conda create -q -n test-environment python=3.7 scipy numpy matplotlib nose pytables flake8
+    else
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy matplotlib nose pytables flake8
+    fi
   - source activate test-environment
   - pip install coveralls
   - pip install pint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,12 @@ branches:
 
 # command to install dependencies
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7-dev" ]]; then
+      PYTHON_VERSION=3.7
+    else
+      PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+    fi
+  - if [[ "$PYTHON_VERSION" == "2.7" ]]; then
       wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -31,7 +36,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy matplotlib nose pytables flake8
+  - conda create -q -n test-environment python=$PYTHON_VERSION scipy numpy matplotlib nose pytables flake8
   - source activate test-environment
   - pip install coveralls
   - pip install pint


### PR DESCRIPTION
Adding Py37 to the build now that 3.7.1 is released. The py37 string is "3.7-dev" is the current way in Travis, but should change to "3.7" one day soon.