### PR TITLE
adds pyrk prefix to package imports in examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # whitelist
 branches:

--- a/examples/default/input.py
+++ b/examples/default/input.py
@@ -1,10 +1,10 @@
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.flibe import Flibe
-from materials.graphite import Graphite
-from materials.kernel import Kernel
-from timer import Timer
+from pyrk.materials.flibe import Flibe
+from pyrk.materials.graphite import Graphite
+from pyrk.materials.kernel import Kernel
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/pbfhr/coupled_0.001_impulse/input.py
+++ b/examples/pbfhr/coupled_0.001_impulse/input.py
@@ -3,13 +3,13 @@
 # parameters are not real material properties, but rather placeholders to
 # check the code
 
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.flibe import Flibe
-from materials.graphite import Graphite
-from materials.kernel import Kernel
-from timer import Timer
+from pyrk.materials.flibe import Flibe
+from pyrk.materials.graphite import Graphite
+from pyrk.materials.kernel import Kernel
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/pbfhr/multi_pt/prt_2ref/input.py
+++ b/examples/pbfhr/multi_pt/prt_2ref/input.py
@@ -7,14 +7,14 @@ The simulation has 3 stages:
 - turn on external reactivity
 '''
 
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.material import Material
-from materials.liquid_material import LiquidMaterial
-from density_model import DensityModel
-from convective_model import ConvectiveModel
-from timer import Timer
+from pyrk.materials.material import Material
+from pyrk.materials.liquid_material import LiquidMaterial
+from pyrk.density_model import DensityModel
+from pyrk.convective_model import ConvectiveModel
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/pbfhr/multi_pt/prt_pke/input.py
+++ b/examples/pbfhr/multi_pt/prt_pke/input.py
@@ -7,14 +7,14 @@ The simulation has 3 stages:
 - turn on external reactivity
 '''
 
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.material import Material
-from materials.liquid_material import LiquidMaterial
-from convective_model import ConvectiveModel
-from density_model import DensityModel
-from timer import Timer
+from pyrk.materials.material import Material
+from pyrk.materials.liquid_material import LiquidMaterial
+from pyrk.convective_model import ConvectiveModel
+from pyrk.density_model import DensityModel
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/pbfhr/multi_pt/rmp_2ref/inpRmp.py
+++ b/examples/pbfhr/multi_pt/rmp_2ref/inpRmp.py
@@ -7,13 +7,13 @@ The simulation has 3 stages:
 - turn on external reactivity
 '''
 
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.material import Material
-from density_model import DensityModel
-from convective_model import ConvectiveModel
-from timer import Timer
+from pyrk.materials.material import Material
+from pyrk.density_model import DensityModel
+from pyrk.convective_model import ConvectiveModel
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/pbfhr/sensitivity/input.py
+++ b/examples/pbfhr/sensitivity/input.py
@@ -6,15 +6,15 @@ The simulation has 3 stages:
 - turn on feedback
 - turn on external reactivity
 '''
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.material import Material
-from materials.liquid_material import LiquidMaterial
-from density_model import DensityModel
-from convective_model import ConvectiveModel
+from pyrk.materials.material import Material
+from pyrk.materials.liquid_material import LiquidMaterial
+from pyrk.density_model import DensityModel
+from pyrk.convective_model import ConvectiveModel
 import random
-from timer import Timer
+from pyrk.timer import Timer
 import numpy as np
 
 #############################################

--- a/examples/sfr/input.py
+++ b/examples/sfr/input.py
@@ -1,10 +1,10 @@
-from utilities.ur import units
-import th_component as th
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
 import math
-from materials.sfrmetal import SFRMetal
-from materials.sodium import Sodium
-from materials.ss316 import SS316
-from timer import Timer
+from pyrk.materials.sfrmetal import SFRMetal
+from pyrk.materials.sodium import Sodium
+from pyrk.materials.ss316 import SS316
+from pyrk.timer import Timer
 
 #############################################
 #

--- a/examples/sfr/min.py
+++ b/examples/sfr/min.py
@@ -1,9 +1,9 @@
 import math
-from utilities.ur import units
-import th_component as th
-from timer import Timer
-from materials.sfrmetal import SFRMetal
-from materials.sodium import Sodium
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
+from pyrk.timer import Timer
+from pyrk.materials.sfrmetal import SFRMetal
+from pyrk.materials.sodium import Sodium
 
 #############################################
 #

--- a/examples/sfr/min_ss.py
+++ b/examples/sfr/min_ss.py
@@ -1,9 +1,9 @@
 import math
-from utilities.ur import units
-import th_component as th
-from timer import Timer
-from materials.sfrmetal import SFRMetal
-from materials.sodium import Sodium
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
+from pyrk.timer import Timer
+from pyrk.materials.sfrmetal import SFRMetal
+from pyrk.materials.sodium import Sodium
 
 #############################################
 #


### PR DESCRIPTION
This PR addresses issue #76, which identified a symptom of the problem.

The problem: The example files wouldn't run because of an "error" in ``validation.py``.
The solution: This error turned out to be a red herring. The example files were not properly importing the pyrk modules. All import statements in those files now have the appropriate ``from pyrk`` or ``from pyrk.[module]``. 

All examples now run appropriately.

Closes #76 