### PR TITLE
Added Profiler and a Progress Bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 # Ignore data &binary files
 *.h5
 *.ace
+*.prof
 
 # Ignore specific files
 matplotlibrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore possible build & documentation
 docs/_build/
 build/
-pyrk\.egg_info/
+pyrk\.egg-info/
 dist/
 RELEASE\-VERSION
 pyrk/RELEASE\-VERSION

--- a/pyrk/driver.py
+++ b/pyrk/driver.py
@@ -271,6 +271,8 @@ def main(args, curr_dir):
     out_db.close_db()
     print(si.plotdir)
     plotter.plot(sol, si)
+
+    ## Profiler Treatment
     profile.disable()
     # Print profiler stats to terminal and log
     s = io.StringIO()
@@ -280,7 +282,8 @@ def main(args, curr_dir):
     print("\nProfiler Stats:\n" + s.getvalue())
     # Print to logger
     pyrklog.info("\nProfiler Stats:\n" + s.getvalue())
-    profile.dump_stats('profile_output')
+    profile.dump_stats(args.profilerstats)
+
     pyrklog.critical("\nSimulation succeeded.\n")
 
 
@@ -288,15 +291,20 @@ def main(args, curr_dir):
 if __name__ == "__main__":
     curr_dir = os.path.dirname(__file__)
     ap = argparse.ArgumentParser(description='PyRK parameters')
-    ap.add_argument('--infile', help='the name of the input file',
+    ap.add_argument('--infile',
+                    help='the name of the input file',
                     default='input')
-    ap.add_argument('--logfile', help='the name of the log file',
+    ap.add_argument('--logfile',
+                    help='the name of the log file',
                     default='pyrk.log')
-    ap.add_argument(
-        '--plotdir',
-        help='the name of the directory of output plots',
-        default='images')
-    ap.add_argument('--outfile', help='the name of the output database',
+    ap.add_argument('--plotdir',
+                    help='the name of the directory of output plots',
+                    default='images')
+    ap.add_argument('--outfile', 
+                    help='the name of the output database',
                     default='pyrk.h5')
+    ap.add_argument('--profilerstats',
+                    help='the name of the profiler stats file',
+                    default='pyrk.prof')
     args = ap.parse_args()
     main(args, curr_dir)

--- a/pyrk/driver.py
+++ b/pyrk/driver.py
@@ -15,7 +15,7 @@ from pyrk.db import database
 from pyrk.utilities import logger
 from pyrk.utilities import plotter
 from pyrk.utilities.logger import pyrklog
-from pyrk.utilities.progressbar import ProgressBar
+from pyrk.utilities.progress_bar import ProgressBar
 from pyrk.inp import sim_info
 from pyrk.utilities.ur import units
 import os
@@ -249,11 +249,16 @@ def post_profiling(profile, args):
     pyrklog.info("\nProfiler Stats:\n" + s.getvalue())
     profile.dump_stats(args.profilerstats)
 
-def main(args, curr_dir):
+def initialize_profiling(args):
     if args.enable_profiler is True:
         import cProfile
         profile = cProfile.Profile()
         profile.enable()
+        return profile
+    return None
+
+def main(args, curr_dir):
+    profile = initialize_profiling(args)
     np.set_printoptions(precision=5, threshold=np.inf)
     logger.set_up_pyrklog(args.logfile)
     infile = load_infile(args.infile)
@@ -283,10 +288,10 @@ def main(args, curr_dir):
     out_db.close_db()
     print(si.plotdir)
     plotter.plot(sol, si)
-
-    if args.enable_profiler is True:
+    if args.enable_profiler is True and profile is not None:
         post_profiling(profile, args)
 
+    pyrklog.critical("\nSimulation succeeded.\n")
     pyrklog.critical("\nSimulation succeeded.\n")
 
 """Run it as a script"""

--- a/pyrk/utilities/progress_bar.py
+++ b/pyrk/utilities/progress_bar.py
@@ -18,57 +18,66 @@ class ProgressBar(object):
 
     def bar_update(self, timer=Timer()):
         """
-        Updates the output to the terminal by calculating
-        the average time between timesteps, finding out how
-        many timesteps are left, then calculating the remaining 
-        time.
+        Responsible for filling the timebar.
 
         :param timer: The timer from the simulation input file
         :type timer: Timer() object  
         """
 
-        # Responsible for filling the timebar
+
         progress = timer.current_timestep()
         total_len = timer.timesteps()
         percent = progress / total_len
         filled_len = int(percent * self.bar_len)
         bar = self.fill * filled_len + "-" * (self.bar_len - filled_len)
 
-        eta_str = self.eta_string(now=time.time(),
-                                  total_len=total_len,
-                                  progress=progress,
-                                  percent=percent)
+        eta_str = self.calculate_eta(real_time=time.time(),
+                                     total_len=total_len,
+                                     progress=progress)
 
         sys.stdout.write(f'\rProgress: [{bar}] | {int(percent * 100):02d}% | {eta_str}')
 
         sys.stdout.flush()
 
 
-    def eta_string(self,now,total_len,progress,percent):
+    def calculate_eta(self,real_time,total_len,progress):
+        """
+        Responsible for Calculating ETA by first checking the amount of time inbetween timesteps 
         
+            (real_time - last_time = time in seconds since the last timestep) 
+
+        It then averages out the time inbetween steps and checks how many steps
+        are left in the simulation.
+
+        :param real_time: The current 'in real life time' like on a clock
+        :param total_len: The number of timesteps in the time array of the sim
+        :total_len type: int
+        :param progress: the index of the current timestep of the time array
+        """
+        
+
         if self.last_time is None: # Initializing for start of sim
-            self.last_time = now
+            self.last_time = real_time
             self.avg_time = 0
             self.last_progress = progress
             eta_str = ""
         
         else:
-            step_time = now - self.last_time #Real time Inbetween steps
-            steps = progress - self.last_progress #Integer step 
+            step_time = real_time - self.last_time #Real time Inbetween steps
+            steps = progress - self.last_progress 
             if steps > 0:
                 if self.avg_time == 0: # First timestep
                     self.avg_time = step_time / steps
                 else:
                     self.avg_time = (self.avg_time * (progress - steps) \
                                         + step_time) / progress
-            self.last_time = now
+            self.last_time = real_time
             self.last_progress = progress
 
-            if percent > 0:
-                eta = (total_len - progress) * self.avg_time
-                hours = int(eta) // 3600
-                minutes = (int(eta) % 3600 ) // 60
-                seconds = int(eta) % 60
-                eta_str = f"ETA {hours:02d}:{minutes:02d}:{seconds:02d}"
+            eta = (total_len - progress) * self.avg_time
+            hours = int(eta) // 3600
+            minutes = (int(eta) % 3600 ) // 60
+            seconds = int(eta) % 60
+            eta_str = f"ETA {hours:02d}:{minutes:02d}:{seconds:02d}"
 
         return eta_str

--- a/pyrk/utilities/progressbar.py
+++ b/pyrk/utilities/progressbar.py
@@ -30,9 +30,13 @@ class ProgressBar(object):
 
         progress = timer.current_timestep()
         total_len = timer.timesteps()
-        percent = progress / total_len
-        filled_len = int(percent * self.bar_len)
-        bar = self.fill * filled_len + "-" * (self.bar_len - filled_len)
+        if progress == total_len:
+            bar = total_len * self.fill
+            percent = int(1)
+        else:
+            percent = progress / total_len
+            filled_len = int(percent * self.bar_len)
+            bar = self.fill * filled_len + "-" * (self.bar_len - filled_len)
 
 
         #ETA treatment

--- a/pyrk/utilities/progressbar.py
+++ b/pyrk/utilities/progressbar.py
@@ -1,0 +1,65 @@
+from pyrk.timer import Timer
+import sys
+import time
+
+
+class ProgressBar(object):
+    """This class holds the progressbar
+    and ETA functions for use in the driver.
+    """
+
+
+    def __init__(self, bar_len=50, fill='█'):
+        self.bar_len = bar_len
+        self.fill = fill
+        self.last_time = None
+        self.avg_time = 0
+        self.last_progress = 0
+
+    def bar_update(self, timer=Timer()):
+
+        """
+        Updates the output to the terminal by calculating
+        the average time between timesteps, finding out how
+        many timesteps are left, then calculating the remaining 
+        time.
+
+        :param timer: The timer from the simulation input file
+        :type timer: Timer() object  
+        """
+
+        progress = timer.current_timestep()
+        total_len = timer.timesteps()
+        percent = progress / total_len
+        filled_len = int(percent * self.bar_len)
+        bar = self.fill * filled_len + "-" * (self.bar_len - filled_len)
+
+
+        #ETA treatment
+        now = time.time()
+        if self.last_time is None:
+            self.last_time = now
+            self.avg_time = 0
+            self.last_progress = progress
+            eta_str = ""
+        else:
+            step_time = now - self.last_time
+            steps = progress - self.last_progress
+            if steps > 0:
+                if self.avg_time == 0:
+                    self.avg_time = step_time / steps
+                else:
+                    self.avg_time = (self.avg_time * (progress - steps) + step_time) / progress
+            self.last_time = now
+            self.last_progress = progress
+            if percent > 0 and self.avg_time:
+                eta = (total_len - progress) * self.avg_time
+                hours = int(eta) // 3600
+                minutes = (int(eta) % 3600 ) // 60
+                seconds = int(eta) % 60
+                eta_str = f"ETA {hours:02d}:{minutes:02d}:{seconds:02d}"
+            else:
+                eta_str = ""
+
+        sys.stdout.write(f'\rProgress: [{bar}] | {int(percent * 100):02d}% | {eta_str}')
+        sys.stdout.flush()


### PR DESCRIPTION
I added cProfiler to the `driver.py` file - specifically within main(). At the end of a simulation, the profiler outputs to the terminal, pyrklog, and to its own file called `profile_output.prof`. 

Additionally for vanity I created the utility `progressbar.py` within /pyrk/utilities to displays a progress bar as well as an ETA in the terminal while a simulation is running. 

The progress bar uses the `Timer()` object from the input file to check how far along the progress is based on the current index and the total length of the time array.. 

For ETA, the model averages the amount of time between timesteps and checks how many timesteps are left for an estimate.