### PR TITLE
Zetas, Omegas, and Component Reactivity written to .h5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore possible build & documentation
 docs/_build/
 build/
-pyrk\.egg_info/
+pyrk\.egg-info/
 dist/
 RELEASE\-VERSION
 pyrk/RELEASE\-VERSION

--- a/input.py
+++ b/input.py
@@ -1,0 +1,208 @@
+from pyrk.utilities.ur import units
+from pyrk import th_component as th
+import math
+from pyrk.materials.flibe import Flibe
+from pyrk.materials.graphite import Graphite
+from pyrk.materials.kernel import Kernel
+from pyrk.timer import Timer
+
+#############################################
+#
+# User Workspace
+#
+#############################################
+
+# Thermal hydraulic params
+# Temperature feedbacks of reactivity
+alpha_f = -3.8 * units.pcm / units.kelvin
+alpha_c = -1.8 * units.pcm / units.kelvin
+alpha_m = -0.7 * units.pcm / units.kelvin
+alpha_r = 1.8 * units.pcm / units.kelvin
+# below from steady state analysis
+t_fuel = 955.58086 * units.kelvin
+t_cool = 936.57636 * units.kelvin
+t_refl = 923.18521 * units.kelvin
+t_mod = 937.39862 * units.kelvin
+t_graph_peb = 936.40806 * units.kelvin
+t_core = 970.54064 * units.kelvin
+
+# the data below comes from design doc rev c
+
+# self._vol_flow_rate = 976.0*0.3 # kg/s TODO 0.3 is nat circ guess
+vel_cool = 2. * units.meter / units.second  # m/s
+t_inlet = units.Quantity(600.0, units.degC)  # degrees C
+# [m] ... matrix(4mm) + coating(1mm)
+thickness_fuel_matrix = 0.005 * units.meter
+kappa = 0.00  # TODO if you fix omegas, kappa ~ 0.06
+core_height = 3.5 * units.meter  # [m] (TODO currently approximate)
+core_inner_radius = 0.35 * units.meter  # m
+core_outer_radius = 1.25 * units.meter  #
+
+# Initial time
+t0 = 0.00 * units.seconds
+
+# Timestep
+dt = 0.005 * units.seconds
+
+# Final Time
+tf = 5.0 * units.seconds
+
+
+def area_sphere(r):
+    assert(r >= 0 * units.meter)
+    return (4.0) * math.pi * pow(r.to('meter'), 2)
+
+
+def vol_sphere(r):
+    assert(r >= 0 * units.meter)
+    return (4. / 3.) * math.pi * pow(r.to('meter'), 3)
+
+
+# volumes
+n_pebbles = 470000
+n_graph_peb = 218000
+n_particles_per_pebble = 4730
+r_pebble = 0.015 * units.meter  # [m] diam = 3cm
+r_core = 0.0125 * units.meter  # [m] diam = 2.5cm
+r_particle = 200 * units.micrometer
+
+# vol of 4730 kernels per pebble, each 400 micrometer diameter
+vol_fuel = n_pebbles * n_particles_per_pebble * vol_sphere(r_particle)
+vol_core = (n_pebbles) * (vol_sphere(r_core))
+vol_mod = (n_pebbles) * (vol_sphere(r_pebble) - vol_sphere(r_core)) - vol_fuel
+vol_graph_peb = (n_graph_peb) * (vol_sphere(r_pebble))
+
+# from design report
+vol_cool = 7.20 * units.meter**3
+mass_inner_refl = 43310.0 * units.kg
+mass_outer_refl = 5940.0 * units.kg
+mass_refl = mass_inner_refl + mass_outer_refl
+rho_refl = 1740.0 * units.kg / units.meter**3
+vol_refl = mass_refl / rho_refl
+
+a_core = area_sphere(r_core) * n_pebbles
+a_mod = area_sphere(r_pebble) * n_pebbles
+a_graph_peb = area_sphere(r_pebble) * n_graph_peb
+a_fuel = area_sphere(r_particle) * n_pebbles * n_particles_per_pebble
+a_refl = 2 * math.pi * core_outer_radius * core_height
+
+# TODO implement h(T) model
+h_mod = 4700 * units.watt / units.kelvin / units.meter**2
+# TODO placeholder
+h_refl = 600 * units.watt / units.kelvin / units.meter**2
+
+# modified alphas for mod
+vol_mod_tot = vol_mod + vol_graph_peb + vol_core
+alpha_mod = alpha_m * vol_mod / vol_mod_tot
+alpha_core = alpha_m * vol_core / vol_mod_tot
+alpha_graph_peb = alpha_m * vol_graph_peb / vol_mod_tot
+
+#############################################
+#
+# Required Input
+#
+#############################################
+
+# Total power, Watts, thermal
+power_tot = 236000000.0 * units.watt
+
+# Timer instance, based on t0, tf, dt
+ti = Timer(t0=t0, tf=tf, dt=dt)
+
+# Number of precursor groups
+n_pg = 6
+
+# Number of decay heat groups
+n_dg = 0
+
+# Fissioning Isotope
+fission_iso = "u235"
+
+# Spectrum
+spectrum = "thermal"
+
+# Feedbacks, False to turn reactivity feedback off. True otherwise.
+feedback = True
+
+# External Reactivity
+from pyrk.reactivity_insertion import StepReactivityInsertion
+rho_ext = StepReactivityInsertion(timer=ti, t_step=1.0 * units.seconds,
+                                  rho_init=0.0 * units.delta_k,
+                                  rho_final=0.005 * units.delta_k)
+
+# maximum number of internal steps that the ode solver will take
+nsteps = 1000
+
+
+fuel = th.THComponent(name="fuel",
+                      mat=Kernel(name="fuelkernel"),
+                      vol=vol_fuel,
+                      T0=t_fuel,
+                      alpha_temp=alpha_f,
+                      timer=ti,
+                      heatgen=True,
+                      power_tot=power_tot)
+
+cool = th.THComponent(name="cool",
+                      mat=Flibe(name="flibe"),
+                      vol=vol_cool,
+                      T0=t_cool,
+                      alpha_temp=alpha_c,
+                      timer=ti)
+
+refl = th.THComponent(name="refl",
+                      mat=Graphite(name="reflgraphite"),
+                      vol=vol_refl,
+                      T0=t_refl,
+                      alpha_temp=alpha_r,
+                      timer=ti)
+
+mod = th.THComponent(name="mod",
+                     mat=Graphite(name="pebgraphite"),
+                     vol=vol_mod,
+                     T0=t_mod,
+                     alpha_temp=alpha_mod,
+                     timer=ti)
+
+core = th.THComponent(name="core",
+                      mat=Graphite(name="pebgraphite"),
+                      vol=vol_core,
+                      T0=t_core,
+                      alpha_temp=alpha_core,
+                      timer=ti)
+
+graph_peb = th.THComponent(name="graph_peb",
+                           mat=Graphite(name="pebgraphite"),
+                           vol=vol_mod,
+                           T0=t_graph_peb,
+                           alpha_temp=alpha_graph_peb,
+                           timer=ti)
+
+components = [fuel, cool, refl, mod, graph_peb, core]
+
+# TODO: verify the conduction lengths and maybe calibrate for spherical components
+# The fuel conducts to the moderator graphite
+fuel.add_conduction('mod', area=a_fuel, L=4 * units.millimeter)
+
+# The moderator graphite conducts to the core graphite
+mod.add_conduction('core', area=a_core, L=25 * units.millimeter)
+# The moderator graphite conducts to the fuel
+mod.add_conduction('fuel', area=a_mod, L=25 * units.millimeter)
+# The moderator graphite convects to the coolant
+mod.add_convection('cool', h=h_mod, area=a_mod)
+
+# The core graphite conducts to the moderator graphite
+core.add_conduction('mod', area=a_core, L=25 * units.centimeter)
+
+# The graphite pebbles convect to the coolant
+graph_peb.add_convection('cool', h=h_mod, area=a_graph_peb)
+
+# The coolant convects accross the graphite pebbles
+cool.add_convection('graph_peb', h=h_mod, area=a_graph_peb)
+# The coolant convects accross the graphite pebbles
+cool.add_convection('mod', h=h_mod, area=a_mod)
+# The coolant convects accross the reflector
+cool.add_convection('refl', h=h_refl, area=a_refl)
+
+# The reflector convects with the coolant
+refl.add_convection('cool', h=h_refl, area=a_refl)

--- a/pyrk/db/database.py
+++ b/pyrk/db/database.py
@@ -228,7 +228,7 @@ class Database(object):
                        'tablename': 'zetas',
                        'description': desc.ZetasTimestepRow,
                        'tabletitle': 'Neutron Precursor Concentrations'})
-        tables.append({'groupname': 'neutronics',
+        tables.append({'groupname': 'th',
                        'tablename': 'omegas',
                        'description': desc.OmegasTimestepRow,
                        'tabletitle': 'Decay Heat Fractions'})

--- a/pyrk/db/descriptions.py
+++ b/pyrk/db/descriptions.py
@@ -3,16 +3,15 @@ import tables as tb
 
 
 class NeutronicsParamsRow(tb.IsDescription):
-    """ A row describing the neutronics parameters in a component..
+    """ A row describing the neutronics parameters.
     """
     t_idx = tb.Int32Col()
-    component = tb.StringCol(16)
     rho_tot = tb.Float64Col()
     rho_ext = tb.Float64Col()
 
 
 class NeutronicsTimeseriesRow(tb.IsDescription):
-    """ A row describing the neutronics data at each timestep
+    """ A row describing the reactivity data in a component at each timestep
     """
     t_idx = tb.Int32Col()
     component = tb.StringCol(16)

--- a/pyrk/inp/sim_info.py
+++ b/pyrk/inp/sim_info.py
@@ -99,14 +99,15 @@ class SimInfo(object):
             self.db.register_recorder('th', 'th_params',
                                       c.metadata,
                                       timeseries=False)
-            self.db.register_recorder('neutronics','neutronics_timeseries',
+            self.db.register_recorder('neutronics', 
+                                      'neutronics_timeseries',
                                       recorder= c.neutronics_metadata,
                                       timeseries=True)
             
 
         for z in range(self.n_pg):
             self.db.register_recorder(
-                'neutronics', 'zetas',
+                'neutronics', 'neutronics_timeseries',
                 recorder=functools.partial(self.zeta_record, z),
                 timeseries=True)
             
@@ -233,13 +234,13 @@ class SimInfo(object):
         return rec
     
     def zeta_record(self, i):
-        """A recorder function for the neutronics/zetas table"""
-        t_idx = self.timer.current_timestep() - 1
-        rec = {
-            "t_idx": t_idx,
-            "zeta_idx": i + 1,
-            "zeta": self.y[t_idx, i + 1]}
-        return rec
+        """A recorder function for the neutronics timeseries table"""
+        for group in range(1,self.n_pg):
+            t_idx = self.timer.current_timestep() - 1
+            rec = {
+                f"zeta_{group}": self.y[t_idx, i + 1]
+                },
+            return rec
     
     def omega_record(self, i):
         """A recorder function for the th/omegas table"""

--- a/pyrk/inp/sim_info.py
+++ b/pyrk/inp/sim_info.py
@@ -82,6 +82,8 @@ class SimInfo(object):
     def register_recorders(self):
         """Registers the function pointers that return database rows
         """
+
+
         self.db.register_recorder('metadata', 'sim_info', self.metadata,
                                   timeseries=False)
         self.db.register_recorder('metadata', 'sim_timeseries', self.record,
@@ -97,17 +99,22 @@ class SimInfo(object):
             self.db.register_recorder('th', 'th_params',
                                       c.metadata,
                                       timeseries=False)
+            self.db.register_recorder('neutronics','neutronics_timeseries',
+                                      recorder= c.neutronics_metadata,
+                                      timeseries=True)
+            
+
         for z in range(self.n_pg):
             self.db.register_recorder(
                 'neutronics', 'zetas',
-                recorder=functools.partial(self.zrecord, z),
+                recorder=functools.partial(self.zeta_record, z),
                 timeseries=True)
             
         if self.n_dg > 0 :
             for o in range(self.n_dg):
                 self.db.register_recorder(
-                    'neutronics', 'omegas',
-                    recorder=functools.partial(self.orecord, o),
+                    'th', 'omegas',
+                    recorder=functools.partial(self.omega_record, o),
                     timeseries=True)
 
     def init_rho_ext(self, rho_ext):
@@ -225,8 +232,8 @@ class SimInfo(object):
                'power': power}
         return rec
     
-    def zrecord(self, i):
-        """Recorder for all DNP (zeta) groups."""
+    def zeta_record(self, i):
+        """A recorder function for the neutronics/zetas table"""
         t_idx = self.timer.current_timestep() - 1
         rec = {
             "t_idx": t_idx,
@@ -234,8 +241,8 @@ class SimInfo(object):
             "zeta": self.y[t_idx, i + 1]}
         return rec
     
-    def orecord(self, i):
-        """Recorder for all Omega groups."""
+    def omega_record(self, i):
+        """A recorder function for the th/omegas table"""
         t_idx = self.timer.current_timestep() - 1
         rec = {
             "t_idx": t_idx,

--- a/pyrk/inp/tests/test_sim_info.py
+++ b/pyrk/inp/tests/test_sim_info.py
@@ -87,3 +87,21 @@ def test_sim_id():
     assert not first_id == next_id
     info.db.close_db()
     info.db.delete_db()
+
+
+def test_zeta_omega_recorder():
+    info = si.SimInfo()
+    omega_record = info.orecord(1)
+    zeta_record = info.zrecord(1)
+
+    assert isinstance(zeta_record, dict)
+    assert "t_idx" and 'zeta_idx' and 'zeta' in zeta_record
+    assert isinstance(zeta_record['t_idx'],int)
+    assert isinstance(zeta_record['zeta_idx'],int)
+    assert isinstance(zeta_record['zeta'],float)
+
+    assert isinstance(omega_record, dict)
+    assert "t_idx" and 'omega_idx' and 'omega' in omega_record
+    assert isinstance(omega_record['t_idx'],int)
+    assert isinstance(omega_record['omega_idx'],int)
+    assert isinstance(omega_record['omega'],float)

--- a/pyrk/inp/tests/test_sim_info.py
+++ b/pyrk/inp/tests/test_sim_info.py
@@ -89,10 +89,10 @@ def test_sim_id():
     info.db.delete_db()
 
 
-def test_zeta_omega_recorder():
+def test_zeta_and_omega_recorder():
     info = si.SimInfo()
-    omega_record = info.orecord(1)
-    zeta_record = info.zrecord(1)
+    omega_record = info.omega_record(1)
+    zeta_record = info.zeta_record(1)
 
     assert isinstance(zeta_record, dict)
     assert "t_idx" and 'zeta_idx' and 'zeta' in zeta_record
@@ -105,3 +105,6 @@ def test_zeta_omega_recorder():
     assert isinstance(omega_record['t_idx'],int)
     assert isinstance(omega_record['omega_idx'],int)
     assert isinstance(omega_record['omega'],float)
+    info.db.close_db()
+    info.db.delete_db()
+

--- a/pyrk/materials/fhrfuel.py
+++ b/pyrk/materials/fhrfuel.py
@@ -1,4 +1,4 @@
-from pyrk.ur import units
+from pyrk.utilities.ur import units
 from pyrk.materials.material import Material
 from pyrk.density_model import DensityModel
 

--- a/pyrk/th_component.py
+++ b/pyrk/th_component.py
@@ -305,7 +305,22 @@ class THComponent(object):
                'power_tot': self.power_tot.magnitude
               }
         return rec
-
+    
+    def neutronics_metadata(self):
+        """A recorder function to hold reactivity in each component for the
+        neutronics/neutronics_timeseries table
+        """
+        timestep = self.timer.current_timestep() - 1
+        if timestep >= 1:
+            rec = {'t_idx': timestep,
+                'component': self.name,
+                'rho': self.temp_reactivity(timestep)}
+        else:
+            rec = {'t_idx': 0,
+                'component': self.name,
+                'rho': 0.0}
+        
+        return rec
 
 class THSuperComponent(THComponent):
 

--- a/pyrk/utilities/plotter.py
+++ b/pyrk/utilities/plotter.py
@@ -111,7 +111,7 @@ def plot_omegas(x, y, si):
     plt.xlabel(r'Time $[s]$')
     plt.ylabel(r'Decay Heat Fractions, $\omega_i [\#/dr^3]$')
     plt.title(r'Decay Heat Fractions, $\omega_i [\#/dr^3]$')
-    saveplot("omegas", plt)
+    saveplot("omegas", plt, si.plotdir)
 
 
 def saveplot(name, plt, plotdir='images'):


### PR DESCRIPTION
This was from a TODO in `database.py` - there was no
function for writing Zetas and Omegas to the database file.

The function now writes the data from the solution array to the 
database tables:

 .h5/neutronics/zetas
.h5/neutronics/omegas 

The tables store timesteps as integers (t_idx) , the indexes of the groups
as integers (zeta_idx and omega_idx), and the actual data from the solution
array (zeta and omega).