### PR TITLE
Add UO2 and Water materials

### DIFF
--- a/pyrk/materials/uo2.py
+++ b/pyrk/materials/uo2.py
@@ -1,0 +1,77 @@
+from pyrk.utilities.ur import units
+from pyrk.materials.material import Material
+from pyrk.density_model import DensityModel
+
+
+class UO2(Material):
+    """This class represents the material properties of UO2 fuel. 
+
+    All of the quantities in this class come from the following reference:
+        
+    Popov, S. G., V. K. Ivanov, J. J. Carbajo, G. L. Yoder
+    2000. ''Thermophysical properties of MOX and UO2 fuels
+    including the effects of radiation'' ORNL/TM-2000/351
+    https://info.ornl.gov/sites/publications/Files/Pub57523.pdf
+    """
+
+    def __init__(self, name='uo2'):
+        """Initalizes a material based on UO2 fuel.
+        A material has intensive (as opposed to extensive) material properties.
+        :param name: The name of the material (i.e., "fuel" or "cool")
+        :type name: str.
+        """
+        Material.__init__(self,
+                          name=name,
+                          k=self.thermal_conductivity(),
+                          cp=self.specific_heat_capacity(),
+                          dm=self.density())
+
+    def thermal_conductivity(self):
+        """
+        UO2 thermal conductivity in [W/m-K]
+
+        Popov et al. present models that account for the effect of radiation
+        and temperature on thermal conducticvity (see Table 6.2 in Popov et
+        al.). For simplicity, we select the unirradiated material at normal
+        operating temperatures (873K)
+        """
+
+        return 3.89 * units.watt / (units.meter * units.kelvin)
+
+    def specific_heat_capacity(self):
+        """Specific heat capacity for UO2 solid fuel [J/kg/K]
+        For UO2, the specific heat capacity at normal operating
+        temperatures for this reactor (~900K) is approximately 309.18 [J/kg/K].
+        See Table 4.3 in Popov et al.
+
+        The temperature dependent model recommended by Popov et al is :
+
+        .. math::
+
+            c_p &= C_1 \\times \\frac{\\theta}{T}^{2} \\times \\frac{e^{\\frac{\\theta}{T}}}{\\right(e^{\\frac{\\theta}{T}} -1\\left)^2}\\\\
+               &+ 2 \\times C_2 \\times T\\\\
+               &+ C_3 \\times E_a \\times e^{\\frac{-E_a}{T}} \\times T^{-2}\\\\
+
+
+        where
+        .. math::
+
+            C_1 &= 302.27\\\\
+            C_2 &= 8.463 \\times 10^{-3}\\\\
+            C_3 &= 8.751 \\times 10^{7}\\\\
+            \\theta &= 548.68\\\\
+            E_a &= 18531.7\\\\
+
+
+        """
+        return 309.18 * units.joule / units.kg / units.kelvin
+
+    def density(self):
+        """
+        UO2 density is 10766kg/m^3 at normal reactor operating temperatures.
+        See Table 4.2 in Popov et al.
+
+        """
+
+        return DensityModel(a=10766 * units.kg / (units.meter**3),
+                            model="constant")

--- a/pyrk/materials/water.py
+++ b/pyrk/materials/water.py
@@ -1,0 +1,67 @@
+from pyrk.utilities.ur import units
+from pyrk.materials.liquid_material import LiquidMaterial
+
+from pyXSteam.XSteam import XSteam
+
+class WaterDensity():
+    def __init__(self, pressure, steam_table):
+        """Initializes the WaterDensity object
+
+        :param pressure: Water pressure in MPa
+        :type pressure: float.
+        :param pressure: XSteam table containing water properties
+        :type pressure: pyXSteam.XSteam.XSteam
+
+        """
+        self.pressure = pressure
+        self.steam_table = steam_table
+
+    def rho(self, temp=0 * units.kelvin):
+        """
+        Returns the density based on the temperature
+
+        :param temp: the temperature
+        :type temp: float.
+        """
+        return self.steam_table.rho_pt(self.pressure, temp.magnitude) * units.kg / pow(units.meter, 3)
+
+class Water(LiquidMaterial):
+    """This class represents Water. It inherits from the material
+    class and possesses attributes intrinsic to water. Relies on the
+    pyxsteam package.
+
+    """
+
+    def __init__(self, name="water", pressure=0.101325):
+        """Initalizes a material
+
+        :param name: The name of the component (i.e., "fuel" or "cool")
+        :type name: str.
+        :param pressure: Water pressure in MPa
+        :type pressure: float.
+        """
+        self._steam_table = XSteam(XSteam.UNIT_SYSTEM_BARE) # m/kg/sec/K/MPa/W
+        self._pressure = pressure
+        LiquidMaterial.__init__(self,
+                                name=name,
+                                k=self.thermal_conductivity(),
+                                cp=self.specific_heat_capacity(),
+                                dm=self.density())
+
+    def thermal_conductivity(self):
+        """Water thermal conductivity in [W/m-K]. Based on the saturated liquid
+        thermal conductivity from pyXSteam.
+        """
+        return self._steam_table.tcL_p(self._pressure) * units.watt / (units.meter * units.kelvin)
+
+    def specific_heat_capacity(self):
+        """Specific heat capacity of water [J/kg/K]. Based on the saturated
+        liquid heat capacity from pyXSteam.
+        """
+        return self._steam_table.CpL_p(self._pressure) * units.joule / (units.kg * units.kelvin)
+
+    def density(self):
+        """
+        Water density as a funciton of T. [kg/m^3]
+        """
+        return WaterDensity(self._pressure, self._steam_table)

--- a/pyrk/materials/water.py
+++ b/pyrk/materials/water.py
@@ -23,6 +23,8 @@ class WaterDensity():
         :param temp: the temperature
         :type temp: float.
         """
+        if temp.magnitude == 0:
+            temp = 900 * units.kelvin
         return self.steam_table.rho_pt(self.pressure, temp.magnitude) * units.kg / pow(units.meter, 3)
 
 class Water(LiquidMaterial):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 pint
 tables
 bokeh
+pyXSteam


### PR DESCRIPTION
This PR adds a UO2 material with thermophysical properties based on [ORNL/TM-2000/351](https://info.ornl.gov/sites/publications/Files/Pub57523.pdf), and a Water material with thermophysical properties derived from the pyXSteam package.

TODO: Add tests